### PR TITLE
Incorrect description

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -273,7 +273,7 @@ variable "file_share_backup_policy" {
 variable "immutability" {
   type        = string
   default     = "Unlocked"
-  description = "(optional) Specify Immutability Setting of vault. Locked, Unlocked, Disabled (default)"
+  description = "(optional) Specify Immutability Setting of vault. Locked, Unlocked (default), Disabled"
 }
 
 variable "lock" {


### PR DESCRIPTION
## Description

The description said `immutability` defaults to `Disabled`, which is incorrect.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
