### PR TITLE
Update default values for VM Backup Policy 

### DIFF
--- a/modules/virtual_machine_policy/main.tf
+++ b/modules/virtual_machine_policy/main.tf
@@ -34,10 +34,10 @@ resource "azurerm_backup_policy_vm" "this" {
 
     content {
       count             = var.vm_backup_policy["retention_monthly"].count != 0 ? regex("^[1-9][0-9]{0,3}$", var.vm_backup_policy["retention_monthly"].count) : null
-      days              = var.vm_backup_policy["retention_monthly"].count != 0 && var.vm_backup_policy.frequency != "Weekly" ? var.vm_backup_policy["retention_monthly"].days : null
-      include_last_days = var.vm_backup_policy["retention_monthly"].count != 0 && var.vm_backup_policy.frequency != "Weekly" ? var.vm_backup_policy["retention_monthly"].include_last_days != null ? var.vm_backup_policy["retention_monthly"].include_last_days : null : null
-      weekdays          = var.vm_backup_policy["retention_monthly"].count != 0 && var.vm_backup_policy.frequency == "Weekly" ? length(var.vm_backup_policy["retention_monthly"].weekdays) != 0 ? var.vm_backup_policy["retention_monthly"].weekdays : null : null
-      weeks             = var.vm_backup_policy["retention_monthly"].count != 0 && var.vm_backup_policy.frequency == "Weekly" ? length(var.vm_backup_policy["retention_monthly"].weeks) != 0 ? var.vm_backup_policy["retention_monthly"].weeks : null : null
+      days              = var.vm_backup_policy["retention_monthly"].count != 0 ? var.vm_backup_policy["retention_monthly"].days : null
+      include_last_days = var.vm_backup_policy["retention_monthly"].count != 0 ? var.vm_backup_policy["retention_monthly"].include_last_days != null ? var.vm_backup_policy["retention_monthly"].include_last_days : null : null
+      weekdays          = var.vm_backup_policy["retention_monthly"].count != 0 ? length(var.vm_backup_policy["retention_monthly"].weekdays) != 0 ? var.vm_backup_policy["retention_monthly"].weekdays : null : null
+      weeks             = var.vm_backup_policy["retention_monthly"].count != 0 ? length(var.vm_backup_policy["retention_monthly"].weeks) != 0 ? var.vm_backup_policy["retention_monthly"].weeks : null : null
     }
   }
   dynamic "retention_weekly" {
@@ -53,11 +53,11 @@ resource "azurerm_backup_policy_vm" "this" {
 
     content {
       count             = var.vm_backup_policy["retention_yearly"].count != 0 && var.vm_backup_policy["retention_yearly"].count != 0 ? regex("^[1-9][0-9]{0,3}$", var.vm_backup_policy["retention_yearly"].count) : null
-      months            = var.vm_backup_policy["retention_yearly"].count != 0 && (var.vm_backup_policy["retention_yearly"].count != 0 && length(var.vm_backup_policy["retention_yearly"].months) > 0) ? var.vm_backup_policy["retention_yearly"].months : []                # var.vm_backup_policy["retention_yearly"].months # 
-      days              = var.vm_backup_policy["retention_yearly"].count != 0 && var.vm_backup_policy.frequency != "Weekly" ? var.vm_backup_policy["retention_yearly"].days : null                                                                                          # (Optional) The days of the month to retain backups of. Must be between 1 and 31.'
-      include_last_days = var.vm_backup_policy["retention_yearly"].count != 0 && var.vm_backup_policy.frequency != "Weekly" ? var.vm_backup_policy["retention_yearly"].include_last_days != null ? var.vm_backup_policy["retention_yearly"].include_last_days : null : null # (Optional) Including the last day of the month, default to false.
-      weekdays          = var.vm_backup_policy["retention_yearly"].count != 0 && var.vm_backup_policy.frequency == "Weekly" ? length(var.vm_backup_policy["retention_yearly"].weekdays) != 0 ? var.vm_backup_policy["retention_yearly"].weekdays : null : null              #  (Optional) The weekday backups to retain . Must be one of Sunday, Monday, Tuesday, Wednesday, Thursday, Friday or Saturday.
-      weeks             = var.vm_backup_policy["retention_yearly"].count != 0 && var.vm_backup_policy.frequency == "Weekly" ? length(var.vm_backup_policy["retention_yearly"].weeks) != 0 ? var.vm_backup_policy["retention_yearly"].weeks : null : null                    #  (Optional) The weeks of the month to retain backups of. Must be one of First, Second, Third, Fourth, Last.
+      months            = var.vm_backup_policy["retention_yearly"].count != 0 && (var.vm_backup_policy["retention_yearly"].count != 0 && length(var.vm_backup_policy["retention_yearly"].months) > 0) ? var.vm_backup_policy["retention_yearly"].months : [] # var.vm_backup_policy["retention_yearly"].months # 
+      days              = var.vm_backup_policy["retention_yearly"].count != 0 ? var.vm_backup_policy["retention_yearly"].days : null                                                                                                                         # (Optional) The days of the month to retain backups of. Must be between 1 and 31.'
+      include_last_days = var.vm_backup_policy["retention_yearly"].count != 0 ? var.vm_backup_policy["retention_yearly"].include_last_days != null ? var.vm_backup_policy["retention_yearly"].include_last_days : null : null                                # (Optional) Including the last day of the month, default to false.
+      weekdays          = var.vm_backup_policy["retention_yearly"].count != 0 ? length(var.vm_backup_policy["retention_yearly"].weekdays) != 0 ? var.vm_backup_policy["retention_yearly"].weekdays : null : null                                             #  (Optional) The weekday backups to retain . Must be one of Sunday, Monday, Tuesday, Wednesday, Thursday, Friday or Saturday.
+      weeks             = var.vm_backup_policy["retention_yearly"].count != 0 ? length(var.vm_backup_policy["retention_yearly"].weeks) != 0 ? var.vm_backup_policy["retention_yearly"].weeks : null : null                                                   #  (Optional) The weeks of the month to retain backups of. Must be one of First, Second, Third, Fourth, Last.
     }
   }
 }

--- a/modules/virtual_machine_policy/variables.tf
+++ b/modules/virtual_machine_policy/variables.tf
@@ -34,28 +34,28 @@ variable "vm_backup_policy" {
       time          = string
       hour_interval = optional(number, null)
       hour_duration = optional(number, null)
-      weekdays      = optional(list(string), [])
+      weekdays      = optional(list(string), null)
     })
 
     retention_weekly = optional(object({
       count    = optional(number, 7)
-      weekdays = optional(list(string), [])
+      weekdays = optional(list(string), null)
     }), {})
 
     retention_monthly = optional(object({
       count             = optional(number, 0)
-      weekdays          = optional(list(string), [])
-      weeks             = optional(list(string), [])
-      days              = optional(list(number), [])
+      weekdays          = optional(list(string), null)
+      weeks             = optional(list(string), null)
+      days              = optional(list(number), null)
       include_last_days = optional(bool, false)
     }), {})
 
     retention_yearly = optional(object({
       count             = optional(number, 0)
-      months            = optional(list(string), [])
-      weekdays          = optional(list(string), [])
-      weeks             = optional(list(string), [])
-      days              = optional(list(number), [])
+      months            = optional(list(string), null)
+      weekdays          = optional(list(string), null)
+      weeks             = optional(list(string), null)
+      days              = optional(list(number), null)
       include_last_days = optional(bool, false)
     }), {})
   })

--- a/variables.tf
+++ b/variables.tf
@@ -450,28 +450,28 @@ variable "vm_backup_policy" {
       time          = string
       hour_interval = optional(number, null)
       hour_duration = optional(number, null)
-      weekdays      = optional(list(string), [])
+      weekdays      = optional(list(string), null)
     })
 
     retention_weekly = optional(object({
       count    = optional(number, 7)
-      weekdays = optional(list(string), [])
+      weekdays = optional(list(string), null)
     }), {})
 
     retention_monthly = optional(object({
       count             = optional(number, 0)
-      weekdays          = optional(list(string), [])
-      weeks             = optional(list(string), [])
-      days              = optional(list(number), [])
+      weekdays          = optional(list(string), null)
+      weeks             = optional(list(string), null)
+      days              = optional(list(number), null)
       include_last_days = optional(bool, false)
     }), {})
 
     retention_yearly = optional(object({
       count             = optional(number, 0)
-      months            = optional(list(string), [])
-      weekdays          = optional(list(string), [])
-      weeks             = optional(list(string), [])
-      days              = optional(list(number), [])
+      months            = optional(list(string), null)
+      weekdays          = optional(list(string), null)
+      weeks             = optional(list(string), null)
+      days              = optional(list(number), null)
       include_last_days = optional(bool, false)
     }), {})
   }))


### PR DESCRIPTION
## Description

This PR updates the default values for the VM backup policy variable to use null instead of [].

it also removes the logic in the monthly and yearly retention blocks to allow week days to be set when using daily backup policies. 

Fixes #94 

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #94" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
