### PR TITLE
Add dependency on recovery services vault VM policy

### DIFF
--- a/main.site.recovery.tf
+++ b/main.site.recovery.tf
@@ -9,6 +9,8 @@ module "backup_protected_vm" {
     vault_name                = azapi_resource.this.name
     vault_resource_group_name = var.resource_group_name
   }
+
+  depends_on = [module.recovery_services_vault_vm_policy]
 }
 
 module "backup_protected_file_share" {


### PR DESCRIPTION
## Description

This adds an explicit dependency to fix the issue described in #122.  Single-line change (plus a line of whitespace), tested with good results in my environment, and it matches the dependency pattern already in use for the backup_protected_file_share module.

Fixes #122
Closes #122

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [X] Azure Verified Module updates:
  - [X] Bugfix containing backwards compatible bug fixes
    - [X] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks